### PR TITLE
Allow QEMU to be run from the build directory

### DIFF
--- a/ppc-boot.sh
+++ b/ppc-boot.sh
@@ -10,7 +10,7 @@
 
 me=${0##*/}
 
-qemu_prefix=/usr
+qemu_prefix=/usr/bin
 buildroot_dir=./buildroot
 quiet=
 
@@ -67,7 +67,7 @@ do
     esac
 done
 
-qemu="$qemu_prefix/bin/qemu-system-ppc"
+qemu="$qemu_prefix/qemu-system-ppc"
 
 if [[ ! -f "$qemu" || ! -f "${qemu}64" ]]; then
     echo "$me: no QEMU binaries in \"$qemu_prefix\" directory"


### PR DESCRIPTION
I don't usually install qemu, so this patch is to allow `--prefix=qemu/build`. There's no `bin` directory in the build dir.