### PR TITLE
Handle qemu errors gracefully

### DIFF
--- a/ppc-boot.sh
+++ b/ppc-boot.sh
@@ -306,6 +306,12 @@ spawn_qemu()
     expect \
 	-c "spawn $qemu_cmd" \
 	-c "set timeout $timeout" \
+	-c 'expect -re "^qemu-system-ppc64: (?!warning:)(.*)" \
+	   	       			 { puts -nonewline stderr "ERROR: $expect_out(1,string)"; \
+					   exit 6 } \
+		   -re "^qemu-system-ppc: (?!warning:)(.*)" \
+	   	       			 { puts -nonewline stderr "ERROR: $expect_out(1,string)"; \
+					   exit 6 }' \
 	-c 'expect "SLOF"                { puts -nonewline stderr "FW "; \
 					   exp_continue } \
 		   "OPAL v"              { puts -nonewline stderr "FW "; \


### PR DESCRIPTION
Presently a qemu error like unknown CPU-model isn't handled gracefully and a test that times-out in such a case will be reported as 'PASSED'. For example

$ ./ppc-boot.sh pseriesle6

pseriesle6 : spawn /usr/bin/qemu-system-ppc64 -m 1G -M pseries -cpu POWER6 -nodefaults -kernel ./buildroot/qemu_ppc64le_pseries-latest/vmlinux -append root=/dev/sda -drive file=./buildroot/qemu_ppc64le_pseries-latest/rootfs.ext2,if=scsi,format=raw -net nic -net user -serial mon:stdio -nographic -snapshot 
qemu-system-ppc64: unable to find CPU model 'POWER6' 
<snip>
(PASSED)

To fix this update the expect script to watch out for qemu reported errors and exit with code '6' in such a case. With the patch ppc-boot.sh correctly reports 'FAILED' for the above test case as shown below:

$ ./ppc-boot.sh pseriesle6
pseriesle6 : spawn /usr/bin/qemu-system-ppc64 -m 1G -M pseries -cpu POWER6 -nodefaults -kernel ./buildroot/qemu_ppc64le_pseries-latest/vmlinux -append root=/dev/sda -drive file=./buildroot/qemu_ppc64le_pseries-latest/rootfs.ext2,if=scsi,format=raw -net nic -net user -serial mon:stdio -nographic -snapshot 
qemu-system-ppc64: unable to find CPU model 'POWER6' ERROR: unable to find CPU model 'POWER6'
(FAILED)